### PR TITLE
Remove extra space/semicolon in attribution

### DIFF
--- a/elevation/js/elevation.js
+++ b/elevation/js/elevation.js
@@ -31,7 +31,7 @@ app.run(function($rootScope) {
 app.controller('ElevationController', function($scope, $rootScope, $sce, $http) {
   //hiking map with terrain
   var cycleMap = L.tileLayer('https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png', {
-    attribution : 'Maps &copy; <a href="https://www.thunderforest.com">Thunderforest, </a>;Data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    attribution : 'Maps &copy; <a href="https://www.thunderforest.com">Thunderforest</a>, Data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
   })
   
   //leaflet slippy map


### PR DESCRIPTION
In the attribution, the comma after Thunderforest is part of the link and there's an extra semicolon before Data.

Trying to make it look like this:
![image](https://cloud.githubusercontent.com/assets/4380498/9972268/d36536ca-5e17-11e5-86a0-2e8eb817a122.png)

Also, we should add a Mapzen link in the attribution...perhaps send it to mapzen.com for now?