### PR TITLE
this fixes some issues with rendering transparent polygons over eachother

### DIFF
--- a/isochrone/index.html
+++ b/isochrone/index.html
@@ -10,6 +10,7 @@
   <div id="map" style="width: 1440px; height: 810px"></div>
   <script src="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.js"></script>
   <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+  <script src="https://npmcdn.com/@turf/turf@3.5.1/turf.min.js"></script>
 
   <script>
     //make a map
@@ -42,60 +43,25 @@
 
         //for each feature compute an axis aligned bounding box
         var features = isochrones.features;
-        var bboxes = [];
-        features.forEach(function(feature) {
-          var box = [feature.geometry.coordinates[0][0].slice(), feature.geometry.coordinates[0][0].slice()];
-          feature.geometry.coordinates.forEach(function(ring) {
-            ring.forEach(function(point) {
-              //min
-              if(point[0] < box[0][0])
-                box[0][0] = point[0];
-              if(point[1] < box[0][1])
-                box[0][1] = point[1];
-              //max
-              if(point[0] > box[1][0])
-                box[1][0] = point[0];
-              if(point[1] > box[1][1])
-                box[1][1] = point[1];
-            });
-          });
-          bboxes.push(box);
-        });
-
-        //test whether the inner bbox lies within the outer
-        var inside = function(outer, inner) {
-          return inner[0][0] >= outer[0][0] && inner[1][0] <= outer[1][0] &&
-                 inner[0][1] >= outer[0][1] && inner[1][1] <= outer[1][1];
-        };
-
-        //for each feature in reverse
-        for(var i = features.length - 1; i > 0; i--) {
-          //make sure we are on the next contour
-          var j = i - 1;
-          while(j >= 0 && features[i].properties.contour == features[j].properties.contour)
-            j--;
-          if(j < 0)
+        for(var k = 0; k < features.length; k++) {
+          //find the next set of contours
+          var i = k + 1;
+          while(i < features.length && features[i].properties.contour == features[k].properties.contour)
+            i++;
+          if(i >= features.length)
             break;
-          //find the first one that fits in this contour
-          var contour = features[j].properties.contour;
-          while(j >= 0 && features[j].properties.contour == contour) {
-            //does it fit as an inner ring this will make a cut out
-            //reversing the winding of this inner is more proper
-            //but it seems this renderer doesnt care at all
-            if(inside(bboxes[j], bboxes[i])) {
-              features[i].geometry.coordinates.forEach(function (p) { features[j].geometry.coordinates.push(p); });
-              break;
-            }
-            j--;
+
+          //cut this one by all of these smaller contours
+          var outer = turf.polygon(features[k].geometry.coordinates);
+          var contour = features[i].properties.contour;
+          while(i < features.length && contour == features[i].properties.contour) {
+            var inner = turf.polygon(features[i].geometry.coordinates);
+            outer = turf.difference(outer, inner);
+            i++;
           }
+          //keep it
+          features[k].geometry = outer.geometry;
         }
-
-
-for(var i = 0; i < features.length; i++){
-if(features[i].properties.contour != 30) {
-features.splice(i, 1);
-}
-}  
 
         //create the geojson object
         geojson = L.geoJson(isochrones, { style: function(feature) { 

--- a/isochrone/index.html
+++ b/isochrone/index.html
@@ -1,59 +1,117 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Isochrones</title>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.css" />
+  <title>Isochrones</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.css" />
 </head>
 <body>
-	<div id="map" style="width: 1440px; height: 810px"></div>
-	<script src="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.js"></script>
-	<script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+  <div id="map" style="width: 1440px; height: 810px"></div>
+  <script src="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.js"></script>
+  <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
 
-	<script>
-		//make a map
-		var map = L.map('map').setView([40.5, -76.5], 9);
-		var geojson = null;
+  <script>
+    //make a map
+    var map = L.map('map').setView([37.8, -122.4], 13);
+    var geojson = null;
 
-		//use osm tiles
-		L.tileLayer('http://b.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-			maxZoom: 18,
-			attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributers'
-		}).addTo(map);
-		
-		//click callback
-		function onMapClick(e) {
-			//build url
-			var url = 'https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-t_16n1c&json=';
-			var json = {
-				locations: [{"lat":e.latlng.lat, "lon":e.latlng.lng}],
-				costing: "auto",
-				contours: [{"time":15},{"time":30},{"time":45},{"time":60}],
-				rings_only: true,
-				denoise: .1
-			};
-			url += escape(JSON.stringify(json));
-			//grab the url
-			$.getJSON(url,function(isochrones){
-				//clear this if its not null
-				if(geojson != null)
-					geojson.removeFrom(map);
-				//create the geojson object
-				geojson = L.geoJson(isochrones, { style: function(feature) { 
-					return { fillColor: feature.properties.fill,
-						 fillOpacity: feature.properties["fill-opacity"],
-						 weight: 1,
-						 color: '#FFFFFF'
-					       };
-				}});
-				//render the geojson
-				geojson.addTo(map);
-			})
-		}
-		
-		//hook up the callback
-		map.on('click', onMapClick);
-	</script>
+    //use osm tiles
+    L.tileLayer('http://b.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 18,
+      attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributers'
+    }).addTo(map);
+    
+    //click callback
+    function onMapClick(e) {
+      //build url
+      var url = 'https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-t_16n1c&json=';
+      var json = {
+        locations: [{"lat":e.latlng.lat, "lon":e.latlng.lng}],
+        costing: "multimodal",
+        contours: [{"time":15},{"time":30},{"time":45},{"time":60}],
+        rings_only: true,
+        denoise: .1
+      };
+      url += escape(JSON.stringify(json));
+      //grab the url
+      $.getJSON(url,function(isochrones){
+        //clear this if its not null
+        if(geojson != null)
+          geojson.removeFrom(map);
+
+        //for each feature compute an axis aligned bounding box
+        var features = isochrones.features;
+        var bboxes = [];
+        features.forEach(function(feature) {
+          var box = [feature.geometry.coordinates[0][0].slice(), feature.geometry.coordinates[0][0].slice()];
+          feature.geometry.coordinates.forEach(function(ring) {
+            ring.forEach(function(point) {
+              //min
+              if(point[0] < box[0][0])
+                box[0][0] = point[0];
+              if(point[1] < box[0][1])
+                box[0][1] = point[1];
+              //max
+              if(point[0] > box[1][0])
+                box[1][0] = point[0];
+              if(point[1] > box[1][1])
+                box[1][1] = point[1];
+            });
+          });
+          bboxes.push(box);
+        });
+
+        //test whether the inner bbox lies within the outer
+        var inside = function(outer, inner) {
+          return inner[0][0] >= outer[0][0] && inner[1][0] <= outer[1][0] &&
+                 inner[0][1] >= outer[0][1] && inner[1][1] <= outer[1][1];
+        };
+
+        //for each feature in reverse
+        for(var i = features.length - 1; i > 0; i--) {
+          //make sure we are on the next contour
+          var j = i - 1;
+          while(j >= 0 && features[i].properties.contour == features[j].properties.contour)
+            j--;
+          if(j < 0)
+            break;
+          //find the first one that fits in this contour
+          var contour = features[j].properties.contour;
+          while(j >= 0 && features[j].properties.contour == contour) {
+            //does it fit as an inner ring this will make a cut out
+            //reversing the winding of this inner is more proper
+            //but it seems this renderer doesnt care at all
+            if(inside(bboxes[j], bboxes[i])) {
+              features[i].geometry.coordinates.forEach(function (p) { features[j].geometry.coordinates.push(p); });
+              break;
+            }
+            j--;
+          }
+        }
+
+
+for(var i = 0; i < features.length; i++){
+if(features[i].properties.contour != 30) {
+features.splice(i, 1);
+}
+}  
+
+        //create the geojson object
+        geojson = L.geoJson(isochrones, { style: function(feature) { 
+          return { fillColor: feature.properties.fill,
+                   fillOpacity: feature.properties["fill-opacity"],
+                   weight: 1,
+                   color: '#FFFFFF'
+                 };
+        }});
+        //render the geojson
+        geojson.addTo(map);
+      })
+    }
+    
+    //hook up the callback
+    map.on('click', onMapClick);
+  </script>
 </body>
 </html>

--- a/routing/js/valhalla.js
+++ b/routing/js/valhalla.js
@@ -489,8 +489,8 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
     locateMarkers = [];
 
     //mark from node
-    if(locate_result.node != null) {
-      var marker = L.circle( [locate_result.node.lat,locate_result.node.lon], 2, { color: '#444', opacity: 1, fill: true, fillColor: '#eee', fillOpacity: 1 });
+    if(locate_result.nodes != null && locate_result.nodes.length > 0) {
+      var marker = L.circle( [locate_result.nodes[0].lat,locate_result.nodes[0].lon], 2, { color: '#444', opacity: 1, fill: true, fillColor: '#eee', fillOpacity: 1 });
       map.addLayer(marker);
       var popup = L.popup({maxHeight : 200});
       popup.setContent("<pre id='json'>" + JSON.stringify(locate_result, null, 2) + "</pre>");


### PR DESCRIPTION
there are lots of problems with rendering contour data as polygons. specifically, contours arent strictly polygons. but it turns out that people like to view them that way when they take the form of isochrones. this presents a hard problem. for any given polygon we need to know which polygons from the next contour smaller are inside of said polygon. i thought of a pretty clever way to do this (as seen in previous commits) but i couldnt get it working properly. so i gave up and used turf.js to do the differencing for me #lazy..

@meghanhade let me know if this is agredious. if not feel free to use as example for explorer.
