### PR TITLE
Add tile layer control to routing demos

### DIFF
--- a/routing/index-internal.html
+++ b/routing/index-internal.html
@@ -73,7 +73,9 @@
 				<option id=production value="https://api.mapbox.com/valhalla/v1/">production</option>
 			</select>
 		    <br>Token:</br>
-                        <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" placeholder = "Enter token."></textarea></br>
+                        <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" placeholder = "Enter token."></textarea>
+        <br>Map Token:</br>
+                        <textarea id="maptoken" rows="1" cols="30" maxlength="100" wrap="hard" placeholder = "Enter token."></textarea></br>
 		    <span style="color:black" class="descriptions">Select a locale:</span><br>
 			<select id = "locale_dropdown" onchange="selectLocale()">
 				<option id=en-US selected="selected" value="en-US">en-US</option>
@@ -231,16 +233,12 @@
     <script type="text/javascript" src="js/elevation/L.Elevation.js"></script>
     <script type="text/javascript" src="js/locate/L.Locate.js"></script>
     <script type="text/javascript" src="https://mapzen.com/js/mapzen.standalone.js"></script>
-        
+
     <!-- Load geocoding plugin after Leaflet -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.1/leaflet-geocoder-mapzen.js"></script>
 
 	<script>
-      var defaultMode = 'auto';
-
-      var road = L.tileLayer('https://b.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-	    attribution : '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributers'
-	  });
+    var defaultMode = 'auto';
 	</script>
 
     <!-- Adding a script block to post message to the parent container (think iframed demos) -->

--- a/routing/index.html
+++ b/routing/index.html
@@ -66,7 +66,7 @@
             <hr>
             <h4>Point & Click Route Testing</h4>
              <br>Token:</br>
-                 <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" onclick="selectEnv()" placeholder = "Enter your token."></textarea></br>
+                 <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" onclick="selectEnv()" placeholder = "Enter your token."></textarea>
              <br>Map Token:</br>
                   <textarea id="maptoken" rows="1" cols="30" maxlength="100" wrap="hard" placeholder = "Enter token."></textarea></br>
                     <span style="color:black" class="descriptions">Select a locale:</span>

--- a/routing/index.html
+++ b/routing/index.html
@@ -66,8 +66,10 @@
             <hr>
             <h4>Point & Click Route Testing</h4>
              <br>Token:</br>
-                 <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" onclick="selectEnv()" placeholder = "Enter your token."></textarea></br>             
-                    <span style="color:black" class="descriptions">Select a locale:</span><br>
+                 <textarea id="token" rows="1" cols="30" maxlength="100" wrap="hard" onclick="selectEnv()" placeholder = "Enter your token."></textarea></br>
+             <br>Map Token:</br>
+                  <textarea id="maptoken" rows="1" cols="30" maxlength="100" wrap="hard" placeholder = "Enter token."></textarea></br>
+                    <span style="color:black" class="descriptions">Select a locale:</span>
 			<select id = "locale_dropdown" onchange="selectLocale()">
 				<option id=en-US selected="selected" value="en-US">en-US</option>
 				<option id=de-DE value="de-DE">de-DE</option>
@@ -224,7 +226,7 @@
     <script type="text/javascript" src="js/elevation/L.Elevation.js"></script>
     <script type="text/javascript" src="js/locate/L.Locate.js"></script>
     <script type="text/javascript" src="https://mapzen.com/js/mapzen.standalone.js"></script>
-        
+
     <!-- Load geocoding plugin after Leaflet -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.4.1/leaflet-geocoder-mapzen.js"></script>
 

--- a/routing/js/valhalla.js
+++ b/routing/js/valhalla.js
@@ -140,10 +140,29 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
     zoom : $rootScope.geobase.zoom,
     zoomControl : true,
   }).setView(manhattan, 13);
-  L.tileLayer('http://b.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  var osmlayer = L.tileLayer('http://b.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
-    attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributers'
-  }).addTo(map);
+    attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+  });
+  osmlayer.addTo(map);
+
+  var mapboxlayer = L.tileLayer('https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}@2x.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+  });
+
+  var baseMaps = {
+    "OSM": osmlayer,
+    "Mapbox": mapboxlayer
+  };
+
+  L.control.layers(baseMaps).addTo(map);
+
+
+  document.getElementById('maptoken').addEventListener('change', function(ev) {
+    var maptoken = event.target.value;
+    mapboxlayer.setUrl('https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}@2x.png?access_token=' + maptoken);
+  });
 
   // If iframed, we're going to have to disable some of the touch interaction
   // to not hijack page scroll. See Stamen's Checklist for Maps: http://content.stamen.com/stamens-checklist-for-maps
@@ -805,7 +824,7 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
         updateHashCosting(costing,bikeoptions,directionsoptions,dtoptions);
       });
     }
-    
+
    if (document.getElementById('walk_btn') != undefined) {
       walkBtn = document.getElementById("walk_btn");
 
@@ -834,7 +853,7 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
         updateHashCosting(costing,null,directionsoptions,dtoptions);
     });
    }
-   
+
    if (document.getElementById('motor_scooter_btn') != undefined) {
       scooterBtn = document.getElementById("motor_scooter_btn");
 
@@ -873,7 +892,7 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
         updateHashCosting(costing,scooteroptions,directionsoptions,dtoptions);
       });
     }
-    
+
     if (document.getElementById('motorcycle_btn') != undefined) {
         motorcycleBtn = document.getElementById("motorcycle_btn");
 
@@ -911,7 +930,7 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
         }
         updateHashCosting(costing,motorcycleoptions,directionsoptions,dtoptions);
      });
-   }   
+   }
 
    if (document.getElementById('multi_btn') != undefined) {
         multiBtn = document.getElementById("multi_btn");
@@ -1032,7 +1051,7 @@ app.controller('RouteController', function($scope, $rootScope, $sce, $http) {
       };
       return scooteroptions;
     }
-    
+
     function setMotorcycleOptions(costing) {
       var stype = document.getElementsByName("stype");
       var use_highways = document.getElementById("use_highways").value;


### PR DESCRIPTION
Adds leaflet layer control to allow selecting mapbox streets base layer.
/cc @dgearhart 

![Pasted_Image_8_22_19__4_11_PM](https://user-images.githubusercontent.com/5665333/63546345-a1153a80-c4f7-11e9-9793-dabb0c208d38.png)
