### PR TITLE
Round seconds in narrative window

### DIFF
--- a/routing/dist/lrm-mapzen-patched.js
+++ b/routing/dist/lrm-mapzen-patched.js
@@ -857,9 +857,9 @@ if (typeof module !== undefined) module.exports = polyline;
 				return Math.round(t / 60) + ' min';
 			} else if (t > 60) {
 				return Math.floor(t / 60) + ' min' +
-					(t % 60 !== 0 ? ' ' + (t % 60) + ' s' : '');
+					(t % 60 !== 0 ? ' ' + Math.round(t % 60) + ' s' : '');
 			} else {
-				return t + ' s';
+				return Math.round(t) + ' s';
 			}
 		},
 
@@ -2123,9 +2123,9 @@ if (typeof module !== undefined) module.exports = polyline;
         return Math.round(t / 60) + ' min';
       } else if (t > 60) {
         return Math.floor(t / 60) + ' min' +
-          (t % 60 !== 0 ? ' ' + (t % 60) + ' s' : '');
+          (t % 60 !== 0 ? ' ' + Math.round(t % 60) + ' s' : '');
       } else {
-        return t + ' s';
+        return Math.round(t) + ' s';
       }
     },
 


### PR DESCRIPTION
Round seconds to avoid excessive digits past decimal point round off seconds in the narrative window (was displaying many digits past the decimal point for short routes).